### PR TITLE
feat: add HTTP security headers to Axum router (#29)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tower-http",
  "tower_governor",
  "tracing",
  "tracing-appender",
@@ -1716,6 +1717,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 regex = "1.10"
 dotenvy = "0.15.7"
 tower_governor = "0.8"
+tower-http = { version = "0.5", features = ["set-header"] }
 axum-extra = { version = "0.12.5", features = ["cookie"] }
 sha2 = "0.10"
 uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use axum::extract::DefaultBodyLimit;
-use axum::http::StatusCode;
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Redirect};
 use axum::{
     Form, Json, Router,
@@ -9,6 +9,7 @@ use axum::{
     routing::{delete, get, post},
 };
 use axum_server::tls_rustls::RustlsConfig;
+use tower_http::set_header::SetResponseHeaderLayer;
 
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -237,7 +238,23 @@ async fn main() {
             "/api/documents/{id}/update",
             post(api_update_document).layer(DefaultBodyLimit::max(100 * 1024 * 1024)),
         )
-        .route("/api/documents/{id}/audit", get(api_get_audit_log));
+        .route("/api/documents/{id}/audit", get(api_get_audit_log))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            header::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_FRAME_OPTIONS,
+            header::HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::X_CONTENT_TYPE_OPTIONS,
+            header::HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CONTENT_SECURITY_POLICY,
+            header::HeaderValue::from_static("default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';"),
+        ));
 
     let port: u16 = env::var("PORTNUM")
         .ok()
@@ -1022,7 +1039,9 @@ async fn api_update_document(
                                         // On Windows, std::fs::rename fails if the destination already exists.
                                         // We attempt to remove it first.
                                         if std::path::Path::new(&document.path).exists() {
-                                            if let Err(e) = tokio::fs::remove_file(&document.path).await {
+                                            if let Err(e) =
+                                                tokio::fs::remove_file(&document.path).await
+                                            {
                                                 warn!(
                                                     "Could not remove existing document file '{}' before rename: {}. Attempting rename anyway.",
                                                     document.path, e
@@ -1089,9 +1108,7 @@ async fn api_update_document(
 
                                         info!(
                                             "Document {} successfully updated to version {} by {}",
-                                            id,
-                                            new_version,
-                                            session.user_id
+                                            id, new_version, session.user_id
                                         );
                                         return (
                                             StatusCode::OK,


### PR DESCRIPTION
- Add `tower-http` dependency with `set-header` feature.
- Implement security header layers to enhance application protection:
- HSTS (Strict-Transport-Security) to enforce HTTPS usage.
- X-Frame-Options (DENY) to protect against clickjacking.
- X-Content-Type-Options (nosniff) to prevent MIME type sniffing.
- Content-Security-Policy (CSP) to restrict resource loading, allowing 'self' and 'unsafe-inline' for compatibility with internal scripts and styles.

close #29 